### PR TITLE
Sanitize message for EIP712 Typed Data

### DIFF
--- a/Sources/EvmKit/Core/Signer/EthSigner.swift
+++ b/Sources/EvmKit/Core/Signer/EthSigner.swift
@@ -23,16 +23,9 @@ class EthSigner {
         try Crypto.ellipticSign(isLegacy ? message : prefixed(message: message), privateKey: privateKey)
     }
 
-    public func parseTypedData(rawJson: Data) throws -> EIP712TypedData {
-        let decoder = JSONDecoder()
-        return try decoder.decode(EIP712TypedData.self, from: rawJson)
-    }
-
-    func signTypedData(message: Data) throws -> Data {
-        let typedData = try parseTypedData(rawJson: message)
-        let hashedMessage = try typedData.signHash()
-
-        return try Crypto.ellipticSign(hashedMessage, privateKey: privateKey)
+    func sign(eip712TypedData: EIP712TypedData) throws -> Data {
+        let signHash = try eip712TypedData.signHash()
+        return try Crypto.ellipticSign(signHash, privateKey: privateKey)
     }
 
 }

--- a/Sources/EvmKit/Core/Signer/Signer.swift
+++ b/Sources/EvmKit/Core/Signer/Signer.swift
@@ -29,12 +29,8 @@ public class Signer {
         try ethSigner.sign(message: message, isLegacy: isLegacy)
     }
 
-    public func parseTypedData(rawJson: Data) throws -> EIP712TypedData {
-        try ethSigner.parseTypedData(rawJson: rawJson)
-    }
-
-    public func signTypedData(message: Data) throws -> Data {
-        try ethSigner.signTypedData(message: message)
+    public func sign(eip712TypedData: EIP712TypedData) throws -> Data {
+        try ethSigner.sign(eip712TypedData: eip712TypedData)
     }
 
 }


### PR DESCRIPTION
- filter out all fields in `message` that do not exist or correspond to `types`