### PR TITLE
Feature/composable transaction syncers

### DIFF
--- a/Sources/EvmKit/Core/Kit.swift
+++ b/Sources/EvmKit/Core/Kit.swift
@@ -228,11 +228,11 @@ public extension Kit {
         transactionSyncManager.set(syncers: syncers)
     }
 
-    var ethereumSyncer: ITransactionSyncer {
+    public var ethereumSyncer: ITransactionSyncer {
         EthereumTransactionSyncer(provider: transactionProvider, storage: transactionSyncerStateStorage)
     }
 
-    var internalSyncer: ITransactionSyncer {
+    public var internalSyncer: ITransactionSyncer {
         InternalTransactionSyncer(provider: transactionProvider, storage: transactionStorage)
     }
 

--- a/Sources/EvmKit/Core/Kit.swift
+++ b/Sources/EvmKit/Core/Kit.swift
@@ -18,6 +18,8 @@ public class Kit {
     private let blockchain: IBlockchain
     private let nonceProvider: NonceProvider
     public let transactionManager: TransactionManager
+    public let transactionStorage: TransactionStorage
+    public let transactionSyncerStateStorage: TransactionSyncerStateStorage
     private let transactionSyncManager: TransactionSyncManager
     private let decorationManager: DecorationManager
     public let eip20Storage: Eip20Storage
@@ -32,6 +34,7 @@ public class Kit {
     public let logger: Logger
 
     init(blockchain: IBlockchain, nonceProvider: NonceProvider, transactionManager: TransactionManager, transactionSyncManager: TransactionSyncManager,
+         transactionStorage: TransactionStorage, transactionSyncerStateStorage: TransactionSyncerStateStorage,
          state: EvmKitState = EvmKitState(), address: Address, chain: Chain, uniqueId: String,
          transactionProvider: ITransactionProvider, decorationManager: DecorationManager, eip20Storage: Eip20Storage,
          logger: Logger)
@@ -40,6 +43,8 @@ public class Kit {
         self.nonceProvider = nonceProvider
         self.transactionManager = transactionManager
         self.transactionSyncManager = transactionSyncManager
+        self.transactionStorage = transactionStorage
+        self.transactionSyncerStateStorage = transactionSyncerStateStorage
         self.state = state
         self.address = address
         self.chain = chain
@@ -219,6 +224,18 @@ public extension Kit {
         transactionSyncManager.add(syncer: transactionSyncer)
     }
 
+    func set(syncers: [ITransactionSyncer]) {
+        transactionSyncManager.set(syncers: syncers)
+    }
+
+    var ethereumSyncer: ITransactionSyncer {
+        EthereumTransactionSyncer(provider: transactionProvider, storage: transactionSyncerStateStorage)
+    }
+
+    var internalSyncer: ITransactionSyncer {
+        InternalTransactionSyncer(provider: transactionProvider, storage: transactionStorage)
+    }
+
     func add(nonceProvider: INonceProvider) {
         self.nonceProvider.add(provider: nonceProvider)
     }
@@ -322,14 +339,12 @@ extension Kit {
         let transactionStorage = try TransactionStorage(databaseDirectoryUrl: dataDirectoryUrl(), databaseFileName: "transactions-\(uniqueId)")
         let transactionSyncerStateStorage = try TransactionSyncerStateStorage(databaseDirectoryUrl: dataDirectoryUrl(), databaseFileName: "transaction-syncer-states-\(uniqueId)")
 
-        let ethereumTransactionSyncer = EthereumTransactionSyncer(provider: transactionProvider, storage: transactionSyncerStateStorage)
-        let internalTransactionSyncer = InternalTransactionSyncer(provider: transactionProvider, storage: transactionStorage)
         let decorationManager = DecorationManager(userAddress: address, storage: transactionStorage)
         let transactionManager = TransactionManager(userAddress: address, storage: transactionStorage, decorationManager: decorationManager, blockchain: blockchain, transactionProvider: transactionProvider)
         let transactionSyncManager = TransactionSyncManager(transactionManager: transactionManager)
 
-        transactionSyncManager.add(syncer: ethereumTransactionSyncer)
-        transactionSyncManager.add(syncer: internalTransactionSyncer)
+        // Transaction syncers are not added here; each consumer composes its own set,
+        // e.g. evmKit.set(syncers: [evmKit.ethereumSyncer, evmKit.internalSyncer, ...]).
 
         let nonceProvider = NonceProvider()
         nonceProvider.add(provider: blockchain)
@@ -338,6 +353,7 @@ extension Kit {
 
         let kit = Kit(
             blockchain: blockchain, nonceProvider: nonceProvider, transactionManager: transactionManager, transactionSyncManager: transactionSyncManager,
+            transactionStorage: transactionStorage, transactionSyncerStateStorage: transactionSyncerStateStorage,
             address: address, chain: chain, uniqueId: uniqueId, transactionProvider: transactionProvider, decorationManager: decorationManager,
             eip20Storage: eip20Storage, logger: logger
         )

--- a/Sources/EvmKit/Core/TransactionStorage.swift
+++ b/Sources/EvmKit/Core/TransactionStorage.swift
@@ -1,10 +1,10 @@
 import Foundation
 import GRDB
 
-class TransactionStorage {
+public class TransactionStorage {
     private let dbPool: DatabasePool
 
-    init(databaseDirectoryUrl: URL, databaseFileName: String) {
+    public init(databaseDirectoryUrl: URL, databaseFileName: String) {
         let databaseURL = databaseDirectoryUrl.appendingPathComponent("\(databaseFileName).sqlite")
 
         dbPool = try! DatabasePool(path: databaseURL.path)

--- a/Sources/EvmKit/Core/TransactionStorage.swift
+++ b/Sources/EvmKit/Core/TransactionStorage.swift
@@ -351,7 +351,7 @@ extension TransactionStorage {
         }
     }
 
-    func lastInternalTransaction() -> InternalTransaction? {
+    public func lastInternalTransaction() -> InternalTransaction? {
         try! dbPool.read { db in
             try InternalTransaction
                 .filter(InternalTransaction.Columns.blockNumber != nil)
@@ -360,13 +360,13 @@ extension TransactionStorage {
         }
     }
 
-    func internalTransactions() -> [InternalTransaction] {
+    public func internalTransactions() -> [InternalTransaction] {
         try! dbPool.read { db in
             try InternalTransaction.fetchAll(db)
         }
     }
 
-    func internalTransactions(hashes: [Data]) -> [InternalTransaction] {
+    public func internalTransactions(hashes: [Data]) -> [InternalTransaction] {
         try! dbPool.read { db in
             try InternalTransaction
                 .filter(hashes.contains(InternalTransaction.Columns.hash))
@@ -374,7 +374,7 @@ extension TransactionStorage {
         }
     }
 
-    func save(internalTransactions: [InternalTransaction]) {
+    public func save(internalTransactions: [InternalTransaction]) {
         try! dbPool.write { db in
             for internalTransaction in internalTransactions {
                 try internalTransaction.save(db)

--- a/Sources/EvmKit/Core/TransactionSyncerStateStorage.swift
+++ b/Sources/EvmKit/Core/TransactionSyncerStateStorage.swift
@@ -1,10 +1,10 @@
 import Foundation
 import GRDB
 
-class TransactionSyncerStateStorage {
+public class TransactionSyncerStateStorage {
     private let dbPool: DatabasePool
 
-    init(databaseDirectoryUrl: URL, databaseFileName: String) {
+    public init(databaseDirectoryUrl: URL, databaseFileName: String) {
         let databaseURL = databaseDirectoryUrl.appendingPathComponent("\(databaseFileName).sqlite")
 
         dbPool = try! DatabasePool(path: databaseURL.path)
@@ -47,13 +47,13 @@ class TransactionSyncerStateStorage {
 }
 
 extension TransactionSyncerStateStorage {
-    func syncerState(syncerId: String) throws -> TransactionSyncerState? {
+    public func syncerState(syncerId: String) throws -> TransactionSyncerState? {
         try dbPool.read { db in
             try TransactionSyncerState.filter(TransactionSyncerState.Columns.syncerId == syncerId).fetchOne(db)
         }
     }
 
-    func save(syncerState: TransactionSyncerState) throws {
+    public func save(syncerState: TransactionSyncerState) throws {
         try dbPool.write { db in
             try syncerState.save(db)
         }

--- a/Sources/EvmKit/Models/InternalTransaction.swift
+++ b/Sources/EvmKit/Models/InternalTransaction.swift
@@ -10,7 +10,7 @@ public class InternalTransaction: Record {
     public let value: BigUInt
     public let traceId: String
 
-    init(hash: Data, blockNumber: Int, from: Address, to: Address, value: BigUInt, traceId: String) {
+    public init(hash: Data, blockNumber: Int, from: Address, to: Address, value: BigUInt, traceId: String) {
         self.hash = hash
         self.blockNumber = blockNumber
         self.from = from

--- a/Sources/EvmKit/Models/ProviderInternalTransaction.swift
+++ b/Sources/EvmKit/Models/ProviderInternalTransaction.swift
@@ -3,13 +3,13 @@ import Foundation
 import ObjectMapper
 
 public struct ProviderInternalTransaction: ImmutableMappable {
-    let hash: Data
-    let blockNumber: Int
-    let timestamp: Int
-    let from: Address
-    let to: Address
-    let value: BigUInt
-    let traceId: String
+    public let hash: Data
+    public let blockNumber: Int
+    public let timestamp: Int
+    public let from: Address
+    public let to: Address
+    public let value: BigUInt
+    public let traceId: String
 
     public init(map: Map) throws {
         hash = try map.value("hash", using: HexDataTransform())
@@ -21,7 +21,25 @@ public struct ProviderInternalTransaction: ImmutableMappable {
         traceId = try map.value("traceId")
     }
 
-    var internalTransaction: InternalTransaction {
+    public init(
+        hash: Data,
+        from: Address,
+        to: Address,
+        value: BigUInt,
+        blockNumber: Int = 0,
+        timestamp: Int = 0,
+        traceId: String = ""
+    ) {
+        self.hash = hash
+        self.blockNumber = blockNumber
+        self.timestamp = timestamp
+        self.from = from
+        self.to = to
+        self.value = value
+        self.traceId = traceId
+    }
+
+    public var internalTransaction: InternalTransaction {
         InternalTransaction(
             hash: hash,
             blockNumber: blockNumber,

--- a/Sources/EvmKit/Models/ProviderTokenTransaction.swift
+++ b/Sources/EvmKit/Models/ProviderTokenTransaction.swift
@@ -40,4 +40,42 @@ public struct ProviderTokenTransaction: ImmutableMappable {
         gasUsed = try map.value("gasUsed", using: StringIntTransform())
         cumulativeGasUsed = try map.value("cumulativeGasUsed", using: StringIntTransform())
     }
+
+    public init(
+        hash: Data,
+        from: Address,
+        contractAddress: Address,
+        to: Address,
+        value: BigUInt,
+        blockNumber: Int = 0,
+        timestamp: Int = 0,
+        nonce: Int = 0,
+        blockHash: Data = Data(),
+        tokenName: String = "",
+        tokenSymbol: String = "",
+        tokenDecimal: Int = 0,
+        transactionIndex: Int = 0,
+        gasLimit: Int = 0,
+        gasPrice: Int = 0,
+        gasUsed: Int = 0,
+        cumulativeGasUsed: Int = 0
+    ) {
+        self.blockNumber = blockNumber
+        self.timestamp = timestamp
+        self.hash = hash
+        self.nonce = nonce
+        self.blockHash = blockHash
+        self.from = from
+        self.contractAddress = contractAddress
+        self.to = to
+        self.value = value
+        self.tokenName = tokenName
+        self.tokenSymbol = tokenSymbol
+        self.tokenDecimal = tokenDecimal
+        self.transactionIndex = transactionIndex
+        self.gasLimit = gasLimit
+        self.gasPrice = gasPrice
+        self.gasUsed = gasUsed
+        self.cumulativeGasUsed = cumulativeGasUsed
+    }
 }

--- a/Sources/EvmKit/Models/TransactionSyncerState.swift
+++ b/Sources/EvmKit/Models/TransactionSyncerState.swift
@@ -1,10 +1,10 @@
 import GRDB
 
-class TransactionSyncerState: Record {
-    let syncerId: String
-    let lastBlockNumber: Int
+public class TransactionSyncerState: Record {
+    public let syncerId: String
+    public let lastBlockNumber: Int
 
-    init(syncerId: String, lastBlockNumber: Int) {
+    public init(syncerId: String, lastBlockNumber: Int) {
         self.syncerId = syncerId
         self.lastBlockNumber = lastBlockNumber
 
@@ -20,7 +20,7 @@ class TransactionSyncerState: Record {
         case lastBlockNumber
     }
 
-    required init(row: Row) throws {
+    public required init(row: Row) throws {
         syncerId = row[Columns.syncerId]
         lastBlockNumber = row[Columns.lastBlockNumber]
 

--- a/Sources/EvmKit/TransactionSyncers/TransactionSyncManager.swift
+++ b/Sources/EvmKit/TransactionSyncers/TransactionSyncManager.swift
@@ -125,6 +125,12 @@ extension TransactionSyncManager {
         }
     }
 
+    func set(syncers: [ITransactionSyncer]) {
+        queue.async {
+            self._syncers = syncers
+        }
+    }
+
     func sync() {
         queue.async {
             self._sync()


### PR DESCRIPTION
- Made transaction syncers composable: Kit.instance no longer auto-adds the ethereum/internal syncers — each app composes its own set.
- Added Kit.set(syncers:) plus Kit.ethereumSyncer / Kit.internalSyncer factories so an app can list the stock syncers or inject custom ones.
- Exposed internal-transaction storage + provider memberwise inits so consumers can read/compose transaction state.
- Note: consumers must now set their syncers explicitly (e.g. evmKit.set(syncers: [evmKit.ethereumSyncer, evmKit.internalSyncer, ...])), otherwise no transactions sync.